### PR TITLE
#23 add reference genome parsing, downgrade python for pyfasta, fix typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
+certifi==2021.10.8
 joblib==1.1.0
 numpy==1.22.3
 pandas==1.4.1
+pyfasta==0.5.2
 python-dateutil==2.8.2
-pytz==2021.3
+pytz==2022.1
 scikit-learn==1.0.2
 scipy==1.8.0
 six==1.16.0

--- a/task_1/utils/data_loader.py
+++ b/task_1/utils/data_loader.py
@@ -2,7 +2,7 @@ import os
 
 import pandas as pd
 
-πTRAIN_INFO = {1: ['X1_train_info', 'X1_val_info'], 2: ['X2_train_info', 'X2_val_info']}
+TRAIN_INFO = {1: ['X1_train_info', 'X1_val_info'], 2: ['X2_train_info', 'X2_val_info']}
 TRAIN_LABELS = {1: ['X1_train_y', 'X1_val_y'], 2: ['X2_train_y', 'X2_val_y']}
 
 

--- a/task_1/utils/seq_loader.py
+++ b/task_1/utils/seq_loader.py
@@ -18,6 +18,14 @@ SEQ_TO_ONEHOT = {
 
 
 def get_sequence(chromosome_nr: int, start: int, stop: int) -> str:
+    """
+    Returns sequence as string in given chromosome with positions [start, stop].
+
+    :param chromosome_nr: chromosome from which to read sequence
+    :param start: first nucleotide position to read
+    :param stop: last nucleotide position to read (includes stop!)
+    :return: sequence as a string
+    """
     return GENOME.sequence({'chr': f'chr{chromosome_nr}', 'start': start, 'stop': stop})
 
 
@@ -43,6 +51,18 @@ def encode_seq(seq: str) -> np.ndarray:
     """
     seq = clean_seq(seq)
     return np.array([SEQ_TO_ONEHOT[nucleotide] for nucleotide in seq])
+
+
+def get_encoded_sequence(chromosome_nr: int, start: int, stop: int) -> np.ndarray:
+    """
+    Returns one-hot encoded sequence in given chromosome with positions [start, stop].
+
+    :param chromosome_nr: chromosome from which to read sequence
+    :param start: first nucleotide position to read
+    :param stop: last nucleotide position to read (includes stop!)
+    :return: One-hot encoded sequence as numpy array
+    """
+    return encode_seq(get_sequence(chromosome_nr, start, stop))
 
 
 if __name__ == '__main__':

--- a/task_1/utils/seq_loader.py
+++ b/task_1/utils/seq_loader.py
@@ -1,0 +1,17 @@
+import os
+
+import pyfasta
+
+
+GENOME_FILE = f'../data/hg38.fa'
+assert os.path.exists(GENOME_FILE)
+
+GENOME = pyfasta.Fasta(GENOME_FILE)
+
+
+def get_sequence(chromosome_nr: int, start: int, stop: int) -> str:
+    return GENOME.sequence({'chr': f'chr{chromosome_nr}', 'start': start, 'stop': stop})
+
+
+if __name__ == '__main__':
+    print(get_sequence(1, 181415, 181565))

--- a/task_1/utils/seq_loader.py
+++ b/task_1/utils/seq_loader.py
@@ -1,17 +1,51 @@
 import os
+from collections import Counter
 
+import numpy as np
 import pyfasta
-
 
 GENOME_FILE = f'../data/hg38.fa'
 assert os.path.exists(GENOME_FILE)
-
 GENOME = pyfasta.Fasta(GENOME_FILE)
+
+SEQ_TO_ONEHOT = {
+    'N': [0, 0, 0, 0],
+    'A': [1, 0, 0, 0],
+    'T': [0, 1, 0, 0],
+    'C': [0, 0, 1, 0],
+    'G': [0, 0, 0, 1]
+}
 
 
 def get_sequence(chromosome_nr: int, start: int, stop: int) -> str:
     return GENOME.sequence({'chr': f'chr{chromosome_nr}', 'start': start, 'stop': stop})
 
 
+def clean_seq(seq: str) -> str:
+    """
+    Cleans the sequence: every letter is in 'ATCGN'.
+
+    :param seq: Input sequence
+    """
+    seq = seq.upper()
+
+    assert lambda key: key in ['A', 'T', 'C', 'G', 'N'], Counter(seq).keys()
+    return seq
+
+
+def encode_seq(seq: str) -> np.ndarray:
+    """
+    Converts given input sequence into a one-hot encoded array.
+    'N' is represented as all zeros.
+
+    :param seq: Input sequence.
+    :return: One-hot encoded sequence as numpy array.
+    """
+    seq = clean_seq(seq)
+    return np.array([SEQ_TO_ONEHOT[nucleotide] for nucleotide in seq])
+
+
 if __name__ == '__main__':
-    print(get_sequence(1, 181415, 181565))
+    sequence = get_sequence(1, 10000, 20000)
+    print(sequence)
+    print(encode_seq(sequence))


### PR DESCRIPTION
Notable things:
- download this file into data folder: `https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa`
- python downgraded due to pyfasta error with 3.10.0

Otherwise, think this is the best way to load sequence, afterwards can add logic due to window and other shifts